### PR TITLE
fix issue with permissions on notes

### DIFF
--- a/app/controllers/notes/view.py
+++ b/app/controllers/notes/view.py
@@ -40,7 +40,7 @@ class view(MixedObject):
 
             if not note.public:
               if not self.session.id or\
-                      self.session.id!=note.user or\
+                      self.session.id!=note.user.id or\
                       not self.session.has_group("notes"):
                   self.session.push_alert("That note is not public and you do not have the rights to access it.",
                                            level="error")


### PR DESCRIPTION
wasn't able to get to a private note after creating it, because it wasn't looking at the users id.

Stupid mistake :/
